### PR TITLE
Fix/additions for 3.2 Crafter Blue Scrip Shop + RB_CN data separation

### DIFF
--- a/ExBuddy/OrderBotTags/Behaviors/Examples/TurnInCollectables.xml
+++ b/ExBuddy/OrderBotTags/Behaviors/Examples/TurnInCollectables.xml
@@ -1,59 +1,107 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
-<!--User Configuration-->
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE Profile [
-<!ENTITY Location "Idyllshire">
-<!--
+<!-- 
+
 		Idyllshire
-		MorDhona - limited options for purchases, some purchase might not work or you might end up with the wrong item (untested)
-	-->
-	
-<!--
-	    CrpDelineation
-        BsmDelineation
-        ArmDelineation
-        GsmDelineation
-        LtwDelineation
-        WvrDelineation
-        AlcDelineation
-        CulDelineation
-        RedCrafterToken
-        RedGatherToken
-        HiCordial
-        BlueToken
-        BruteLeech
-        CraneFly
-        KukuruPowder
-        BouillonCube
-        BeanSauce
-        BeanPaste
-	-->
-<!ENTITY ShopPurchase1 "BlueToken">
-<!ENTITY ShopPurchase1_Count "900">
-<!ENTITY ShopPurchase2 "HiCordial">
-<!ENTITY ShopPurchase2_Count "10">
-<!ENTITY ShopPurchase3 "BruteLeech">
-<!ENTITY ShopPurchase3_Count "0">
+
+BlueToken
+RedCrafterToken
+RedGatherToken
+HiCordial
+CommercialSurvivalManual
+CommercialEngineeringManual
+RedBalloon
+MagmaWorm
+FiendWorm
+BruteLeech
+CraneFly
+KukuruPowder
+BouillonCube
+BeanSauce
+BeanPaste
+GoldenApple
+SolsticeGarlic
+MatureOliveOil
+LoaghtanFilet
+PowderedMermanHorn
+CrpDelineation
+BsmDelineation
+ArmDelineation
+GsmDelineation
+LtwDelineation
+WvrDelineation
+AlcDelineation
+CulDelineation
+
+ -->
+
+<!ENTITY BlueToken_Count "0">
+<!ENTITY RedCrafterToken_Count "999">
+<!ENTITY RedGatherToken_Count "0">
+<!ENTITY HiCordial_Count "0">
+<!ENTITY CommercialSurvivalManual_Count "0">
+<!ENTITY CommercialEngineeringManual_Count "0">
+<!ENTITY RedBalloon_Count "0">
+<!ENTITY MagmaWorm_Count "0">
+<!ENTITY FiendWorm_Count "0">
+<!ENTITY BruteLeech_Count "0">
+<!ENTITY CraneFly_Count "0">
+<!ENTITY KukuruPowder_Count "0">
+<!ENTITY BouillonCube_Count "0">
+<!ENTITY BeanSauce_Count "0">
+<!ENTITY BeanPaste_Count "0">
+<!ENTITY GoldenApple_Count "0">
+<!ENTITY SolsticeGarlic_Count "0">
+<!ENTITY MatureOliveOil_Count "0">
+<!ENTITY LoaghtanFilet_Count "0">
+<!ENTITY PowderedMermanHorn_Count "0">
+<!ENTITY CrpDelineation_Count "0">
+<!ENTITY BsmDelineation_Count "0">
+<!ENTITY ArmDelineation_Count "0">
+<!ENTITY GsmDelineation_Count "0">
+<!ENTITY LtwDelineation_Count "0">
+<!ENTITY WvrDelineation_Count "0">
+<!ENTITY AlcDelineation_Count "0">
+<!ENTITY CulDelineation_Count "0">
+
 ]>
 <Profile>
 	<Name>ExBuddy: Turn in Collectables</Name>
 	<KillRadius>50</KillRadius>
 	<Order>
+		<ExLog Color="#FFC0CB" Name="ExBuddy" Message="Turning in collectables "/>
 		<!-- if forcePurchase="true" it will go purchase items even if no turn ins available -->
-		<TurnInCollectables location="&Location;" forcePurchase="false">
-			<Collectables>
-				<CollectableTurnIn name="Abalathian Mistletoe" value="450" />
-				<CollectableTurnIn name="Adamantite Ore" value="470" maxValueForTurnIn="529" />
-				<CollectableTurnIn name="Chysahl Greens" value="470" maxValueForTurnIn="529" />
-				<CollectableTurnIn name="Cuprite" value="450" />
-				<CollectableTurnIn name="Morel" value="450" />
-				<CollectableTurnIn name="Illuminati Perch" value="826" />
-			</Collectables>
+		<ExTurnInCollectables location="Idyllshire" forcePurchase="False">
 			<ShopPurchases>
-				<ShopPurchase shopItem="&ShopPurchase1;" maxCount="&ShopPurchase1_Count;" />
-				<ShopPurchase shopItem="&ShopPurchase2;" maxCount="&ShopPurchase2_Count;" />
-				<ShopPurchase shopItem="&ShopPurchase3;" maxCount="&ShopPurchase3_Count;" />
+				<ShopPurchase shopItem="BlueToken" maxCount="&BlueToken_Count;" />
+				<ShopPurchase shopItem="RedCrafterToken" maxCount="&RedCrafterToken_Count;" />
+				<ShopPurchase shopItem="RedGatherToken" maxCount="&RedGatherToken_Count;" />
+				<ShopPurchase shopItem="HiCordial" maxCount="&HiCordial_Count;" />
+				<ShopPurchase shopItem="CommercialSurvivalManual" maxCount="&CommercialSurvivalManual_Count;" />
+				<ShopPurchase shopItem="CommercialEngineeringManual" maxCount="&CommercialEngineeringManual_Count;" />
+				<ShopPurchase shopItem="RedBalloon" maxCount="&RedBalloon_Count;" />
+				<ShopPurchase shopItem="MagmaWorm" maxCount="&MagmaWorm_Count;" />
+				<ShopPurchase shopItem="FiendWorm" maxCount="&FiendWorm_Count;" />
+				<ShopPurchase shopItem="BruteLeech" maxCount="&BruteLeech_Count;" />
+				<ShopPurchase shopItem="CraneFly" maxCount="&CraneFly_Count;" />
+				<ShopPurchase shopItem="KukuruPowder" maxCount="&KukuruPowder_Count;" />
+				<ShopPurchase shopItem="BouillonCube" maxCount="&BouillonCube_Count;" />
+				<ShopPurchase shopItem="BeanSauce" maxCount="&BeanSauce_Count;" />
+				<ShopPurchase shopItem="BeanPaste" maxCount="&BeanPaste_Count;" />
+				<ShopPurchase shopItem="GoldenApple" maxCount="&GoldenApple_Count;" />
+				<ShopPurchase shopItem="SolsticeGarlic" maxCount="&SolsticeGarlic_Count;" />
+				<ShopPurchase shopItem="MatureOliveOil" maxCount="&MatureOliveOil_Count;" />
+				<ShopPurchase shopItem="LoaghtanFilet" maxCount="&LoaghtanFilet_Count;" />
+				<ShopPurchase shopItem="PowderedMermanHorn" maxCount="&PowderedMermanHorn_Count;" />
+				<ShopPurchase shopItem="CrpDelineation" maxCount="&CrpDelineation_Count;" />
+				<ShopPurchase shopItem="BsmDelineation" maxCount="&BsmDelineation_Count;" />
+				<ShopPurchase shopItem="ArmDelineation" maxCount="&ArmDelineation_Count;" />
+				<ShopPurchase shopItem="GsmDelineation" maxCount="&GsmDelineation_Count;" />
+				<ShopPurchase shopItem="LtwDelineation" maxCount="&LtwDelineation_Count;" />
+				<ShopPurchase shopItem="WvrDelineation" maxCount="&WvrDelineation_Count;" />
+				<ShopPurchase shopItem="AlcDelineation" maxCount="&AlcDelineation_Count;" />
+				<ShopPurchase shopItem="CulDelineation" maxCount="&CulDelineation_Count;" />
 			</ShopPurchases>
-		</TurnInCollectables>
+		</ExTurnInCollectables>
 	</Order>
 </Profile>

--- a/ExBuddy/OrderBotTags/Behaviors/Objects/Data.cs
+++ b/ExBuddy/OrderBotTags/Behaviors/Objects/Data.cs
@@ -92,6 +92,208 @@ namespace ExBuddy.OrderBotTags.Behaviors.Objects
 
 		public static readonly Dictionary<ShopItem, ShopItemInfo> ShopItemMap = new Dictionary<ShopItem, ShopItemInfo>
 																					{
+																						
+																						#if RB_CN
+																						{
+																							ShopItem.CrpDelineation,
+																							new ShopItemInfo
+																								{
+																									Index = 8 + (int)ShopItem.CrpDelineation,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12667 + (int)ShopItem.CrpDelineation,
+																									Cost = 250,
+																									Yield = 10
+																								}
+																						},
+																						{
+																							ShopItem.BsmDelineation,
+																							new ShopItemInfo
+																								{
+																									Index = 8 + (int)ShopItem.BsmDelineation,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12667 + (int)ShopItem.BsmDelineation,
+																									Cost = 250,
+																									Yield = 10
+																								}
+																						},
+																						{
+																							ShopItem.ArmDelineation,
+																							new ShopItemInfo
+																								{
+																									Index = 8 + (int)ShopItem.ArmDelineation,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12667 + (int)ShopItem.ArmDelineation,
+																									Cost = 250,
+																									Yield = 10
+																								}
+																						},
+																						{
+																							ShopItem.GsmDelineation,
+																							new ShopItemInfo
+																								{
+																									Index = 8 + (int)ShopItem.GsmDelineation,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12667 + (int)ShopItem.GsmDelineation,
+																									Cost = 250,
+																									Yield = 10
+																								}
+																						},
+																						{
+																							ShopItem.LtwDelineation,
+																							new ShopItemInfo
+																								{
+																									Index = 8 + (int)ShopItem.LtwDelineation,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12667 + (int)ShopItem.LtwDelineation,
+																									Cost = 250,
+																									Yield = 10
+																								}
+																						},
+																						{
+																							ShopItem.WvrDelineation,
+																							new ShopItemInfo
+																								{
+																									Index = 8 + (int)ShopItem.WvrDelineation,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12667 + (int)ShopItem.WvrDelineation,
+																									Cost = 250,
+																									Yield = 10
+																								}
+																						},
+																						{
+																							ShopItem.AlcDelineation,
+																							new ShopItemInfo
+																								{
+																									Index = 8 + (int)ShopItem.AlcDelineation,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12667 + (int)ShopItem.AlcDelineation,
+																									Cost = 250,
+																									Yield = 10
+																								}
+																						},
+																						{
+																							ShopItem.CulDelineation,
+																							new ShopItemInfo
+																								{
+																									Index = 8 + (int)ShopItem.CulDelineation,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12667 + (int)ShopItem.CulDelineation,
+																									Cost = 250,
+																									Yield = 10
+																								}
+																						},
+																						{
+																							ShopItem.RedCrafterToken,
+																							new ShopItemInfo
+																								{
+																									Index = 0,
+																									ShopType = ShopType.RedCrafter,
+																									ItemId = 12838,
+																									Cost = 50,
+																									Yield = 1
+																								}
+																						},
+																						{
+																							ShopItem.RedGatherToken,
+																							new ShopItemInfo
+																								{
+																									Index = 0,
+																									ShopType = ShopType.RedGatherer,
+																									ItemId = 12840,
+																									Cost = 50,
+																									Yield = 1
+																								}
+																						},
+																						{
+																							ShopItem.HiCordial,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.HiCordial,
+																									ShopType = ShopType.BlueGatherer,
+																									ItemId = 12669,
+																									Cost = 100,
+																									Yield = 1
+																								}
+																						},
+																						{
+																							ShopItem.BlueToken,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.BlueToken,
+																									ShopType = ShopType.BlueGatherer,
+																									ItemId = 12841,
+																									Cost = 250,
+																									Yield = 5
+																								}
+																						},
+																						{
+																							ShopItem.BruteLeech,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.BruteLeech,
+																									ShopType = ShopType.BlueGatherer,
+																									ItemId = 12711,
+																									Cost = 60,
+																									Yield = 50
+																								}
+																						},
+																						{
+																							ShopItem.CraneFly,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.CraneFly,
+																									ShopType = ShopType.BlueGatherer,
+																									ItemId = 12712,
+																									Cost = 60,
+																									Yield = 50
+																								}
+																						},
+																						{
+																							ShopItem.KukuruPowder,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.KukuruPowder,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12886,
+																									Cost = 50,
+																									Yield = 1
+																								}
+																						},
+																						{
+																							ShopItem.BouillonCube,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.BouillonCube,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12905,
+																									Cost = 40,
+																									Yield = 5
+																								}
+																						},
+																						{
+																							ShopItem.BeanSauce,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.BeanSauce,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12906,
+																									Cost = 30,
+																									Yield = 1
+																								}
+																						},
+																						{
+																							ShopItem.BeanPaste,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.BeanPaste,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12907,
+																									Cost = 30,
+																									Yield = 1
+																								}
+																						}
+																										
+																						#else
 																						{
 																							ShopItem.CrpDelineation,
 																							new ShopItemInfo
@@ -400,6 +602,7 @@ namespace ExBuddy.OrderBotTags.Behaviors.Objects
 																									Yield = 5
 																								}
 																						}
+																						#endif
 																					};
 
 		public static IEnumerable<INpc> GetNpcsByLocation(Locations location)

--- a/ExBuddy/OrderBotTags/Behaviors/Objects/Data.cs
+++ b/ExBuddy/OrderBotTags/Behaviors/Objects/Data.cs
@@ -1,4 +1,4 @@
-﻿namespace ExBuddy.OrderBotTags.Behaviors.Objects
+namespace ExBuddy.OrderBotTags.Behaviors.Objects
 {
 	using System.Collections.Generic;
 	using System.Linq;
@@ -40,22 +40,22 @@
 																									{
 																										AetheryteId = 75,
 																										ZoneId = 478,
-#if RB_CN
- Location = new Vector3("-15.64056, 211, 0.1677856"),                                                                             
-#else
- Location = new Vector3("-17.29029, 206.4994, 48.57777"),
-#endif
+																										#if RB_CN
+																										 Location = new Vector3("-15.64056, 211, 0.1677856"),                                                                             
+																										#else
+																										 Location = new Vector3("-18.29561, 206.5211, 45.12088"),
+																										#endif
                                                                                                     NpcId = 1012300
 																									},
 																								new ShopExchangeCurrency
 																									{
 																										AetheryteId = 75,
 																										ZoneId = 478,
-#if RB_CN
- Location = new Vector3("-17.38013, 211, -1.66333"),                                                                                           
-#else
- Location = new Vector3("-17.29029, 206.4994, 48.57777"),
-#endif
+																										#if RB_CN
+																										 Location = new Vector3("-17.38013, 211, -1.66333"),                                                                                           
+																										#else
+																										 Location = new Vector3("-20.6455, 206.5211, 47.25714"),
+																										#endif
 																										NpcId = 1012301
 																									}
 																							}
@@ -96,9 +96,9 @@
 																							ShopItem.CrpDelineation,
 																							new ShopItemInfo
 																								{
-																									Index = 8 + (int)ShopItem.CrpDelineation,
+																									Index = 10 + (int)ShopItem.CrpDelineation,
 																									ShopType = ShopType.BlueCrafter,
-																									ItemId = 12667 + (int)ShopItem.CrpDelineation,
+																									ItemId = 12669 + (int)ShopItem.CrpDelineation,
 																									Cost = 250,
 																									Yield = 10
 																								}
@@ -107,9 +107,9 @@
 																							ShopItem.BsmDelineation,
 																							new ShopItemInfo
 																								{
-																									Index = 8 + (int)ShopItem.BsmDelineation,
+																									Index = 10 + (int)ShopItem.BsmDelineation,
 																									ShopType = ShopType.BlueCrafter,
-																									ItemId = 12667 + (int)ShopItem.BsmDelineation,
+																									ItemId = 12669 + (int)ShopItem.BsmDelineation,
 																									Cost = 250,
 																									Yield = 10
 																								}
@@ -118,9 +118,9 @@
 																							ShopItem.ArmDelineation,
 																							new ShopItemInfo
 																								{
-																									Index = 8 + (int)ShopItem.ArmDelineation,
+																									Index = 10 + (int)ShopItem.ArmDelineation,
 																									ShopType = ShopType.BlueCrafter,
-																									ItemId = 12667 + (int)ShopItem.ArmDelineation,
+																									ItemId = 12669 + (int)ShopItem.ArmDelineation,
 																									Cost = 250,
 																									Yield = 10
 																								}
@@ -129,9 +129,9 @@
 																							ShopItem.GsmDelineation,
 																							new ShopItemInfo
 																								{
-																									Index = 8 + (int)ShopItem.GsmDelineation,
+																									Index = 10 + (int)ShopItem.GsmDelineation,
 																									ShopType = ShopType.BlueCrafter,
-																									ItemId = 12667 + (int)ShopItem.GsmDelineation,
+																									ItemId = 12669 + (int)ShopItem.GsmDelineation,
 																									Cost = 250,
 																									Yield = 10
 																								}
@@ -140,9 +140,9 @@
 																							ShopItem.LtwDelineation,
 																							new ShopItemInfo
 																								{
-																									Index = 8 + (int)ShopItem.LtwDelineation,
+																									Index = 10 + (int)ShopItem.LtwDelineation,
 																									ShopType = ShopType.BlueCrafter,
-																									ItemId = 12667 + (int)ShopItem.LtwDelineation,
+																									ItemId = 12669 + (int)ShopItem.LtwDelineation,
 																									Cost = 250,
 																									Yield = 10
 																								}
@@ -151,9 +151,9 @@
 																							ShopItem.WvrDelineation,
 																							new ShopItemInfo
 																								{
-																									Index = 8 + (int)ShopItem.WvrDelineation,
+																									Index = 10 + (int)ShopItem.WvrDelineation,
 																									ShopType = ShopType.BlueCrafter,
-																									ItemId = 12667 + (int)ShopItem.WvrDelineation,
+																									ItemId = 12669 + (int)ShopItem.WvrDelineation,
 																									Cost = 250,
 																									Yield = 10
 																								}
@@ -162,9 +162,9 @@
 																							ShopItem.AlcDelineation,
 																							new ShopItemInfo
 																								{
-																									Index = 8 + (int)ShopItem.AlcDelineation,
+																									Index = 10 + (int)ShopItem.AlcDelineation,
 																									ShopType = ShopType.BlueCrafter,
-																									ItemId = 12667 + (int)ShopItem.AlcDelineation,
+																									ItemId = 12669 + (int)ShopItem.AlcDelineation,
 																									Cost = 250,
 																									Yield = 10
 																								}
@@ -173,11 +173,22 @@
 																							ShopItem.CulDelineation,
 																							new ShopItemInfo
 																								{
-																									Index = 8 + (int)ShopItem.CulDelineation,
+																									Index = 10 + (int)ShopItem.CulDelineation,
 																									ShopType = ShopType.BlueCrafter,
-																									ItemId = 12667 + (int)ShopItem.CulDelineation,
+																									ItemId = 12669 + (int)ShopItem.CulDelineation,
 																									Cost = 250,
 																									Yield = 10
+																								}
+																						},
+																						{
+																							ShopItem.CommercialEngineeringManual,
+																							new ShopItemInfo
+																								{
+																									Index = 10 + (int)ShopItem.CommercialEngineeringManual,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 12669 + (int)ShopItem.CommercialEngineeringManual,
+																									Cost = 45,
+																									Yield = 1
 																								}
 																						},
 																						{
@@ -203,6 +214,17 @@
 																								}
 																						},
 																						{
+																							ShopItem.CommercialSurvivalManual,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.CommercialSurvivalManual,
+																									ShopType = ShopType.BlueGatherer,
+																									ItemId = 12668,
+																									Cost = 75,
+																									Yield = 1
+																								}
+																						},
+																						{
 																							ShopItem.HiCordial,
 																							new ShopItemInfo
 																								{
@@ -222,6 +244,39 @@
 																									ItemId = 12841,
 																									Cost = 250,
 																									Yield = 5
+																								}
+																						},
+																						{
+																							ShopItem.RedBalloon,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.RedBalloon,
+																									ShopType = ShopType.BlueGatherer,
+																									ItemId = 12708,
+																									Cost = 50,
+																									Yield = 50
+																								}
+																						},
+																						{
+																							ShopItem.MagmaWorm,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.MagmaWorm,
+																									ShopType = ShopType.BlueGatherer,
+																									ItemId = 12709,
+																									Cost = 52,
+																									Yield = 50
+																								}
+																						},
+																						{
+																							ShopItem.FiendWorm,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.FiendWorm,
+																									ShopType = ShopType.BlueGatherer,
+																									ItemId = 12710,
+																									Cost = 55,
+																									Yield = 50
 																								}
 																						},
 																						{
@@ -254,7 +309,7 @@
 																									ShopType = ShopType.BlueCrafter,
 																									ItemId = 12886,
 																									Cost = 50,
-																									Yield = 1
+																									Yield = 3
 																								}
 																						},
 																						{
@@ -288,6 +343,61 @@
 																									ItemId = 12907,
 																									Cost = 30,
 																									Yield = 1
+																								}
+																						},
+																								{
+																							ShopItem.GoldenApple,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.GoldenApple,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 14142,
+																									Cost = 50,
+																									Yield = 5
+																								}
+																						},
+																								{
+																							ShopItem.SolsticeGarlic,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.SolsticeGarlic,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 14143,
+																									Cost = 50,
+																									Yield = 5
+																								}
+																						},
+																								{
+																							ShopItem.MatureOliveOil,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.MatureOliveOil,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 14144,
+																									Cost = 50,
+																									Yield = 5
+																								}
+																						},
+																								{
+																							ShopItem.LoaghtanFilet,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.LoaghtanFilet,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 14145,
+																									Cost = 50,
+																									Yield = 5
+																								}
+																						},
+																								{
+																							ShopItem.PowderedMermanHorn,
+																							new ShopItemInfo
+																								{
+																									Index = (int)ShopItem.PowderedMermanHorn,
+																									ShopType = ShopType.BlueCrafter,
+																									ItemId = 14937,
+																									Cost = 60,
+																									Yield = 5
 																								}
 																						}
 																					};

--- a/ExBuddy/OrderBotTags/Behaviors/Objects/ShopItem.cs
+++ b/ExBuddy/OrderBotTags/Behaviors/Objects/ShopItem.cs
@@ -2,6 +2,44 @@ namespace ExBuddy.OrderBotTags.Behaviors.Objects
 {
 	public enum ShopItem
 	{
+		#if RB_CN
+		CrpDelineation = -8,
+
+		BsmDelineation = -7,
+
+		ArmDelineation = -6,
+
+		GsmDelineation = -5,
+
+		LtwDelineation = -4,
+
+		WvrDelineation = -3,
+
+		AlcDelineation = -2,
+
+		CulDelineation = -1,
+
+		RedCrafterToken = 0,
+
+		RedGatherToken = 1,
+
+		HiCordial = 6,
+
+		BlueToken = 8,
+
+		BruteLeech = 12,
+
+		CraneFly = 13,
+
+		KukuruPowder = 22,
+
+		BouillonCube = 23,
+
+		BeanSauce = 24,
+
+		BeanPaste = 25
+		
+		#else																								
 		CrpDelineation = -10,
 
 		BsmDelineation = -9,
@@ -57,5 +95,6 @@ namespace ExBuddy.OrderBotTags.Behaviors.Objects
 		LoaghtanFilet = 37,
 		
 		PowderedMermanHorn = 38,
+		#endif
 	}
 }

--- a/ExBuddy/OrderBotTags/Behaviors/Objects/ShopItem.cs
+++ b/ExBuddy/OrderBotTags/Behaviors/Objects/ShopItem.cs
@@ -2,40 +2,60 @@ namespace ExBuddy.OrderBotTags.Behaviors.Objects
 {
 	public enum ShopItem
 	{
-		CrpDelineation = -8,
+		CrpDelineation = -10,
 
-		BsmDelineation = -7,
+		BsmDelineation = -9,
 
-		ArmDelineation = -6,
+		ArmDelineation = -8,
 
-		GsmDelineation = -5,
+		GsmDelineation = -7,
 
-		LtwDelineation = -4,
+		LtwDelineation = -6,
 
-		WvrDelineation = -3,
+		WvrDelineation = -5,
 
-		AlcDelineation = -2,
+		AlcDelineation = -4,
 
-		CulDelineation = -1,
-
+		CulDelineation = -3,
+		
+		CommercialEngineeringManual = -2,
+		
 		RedCrafterToken = 0,
 
 		RedGatherToken = 1,
-
+				
+		CommercialSurvivalManual = 5,
+				
 		HiCordial = 6,
 
 		BlueToken = 8,
+		
+		RedBalloon = 9,
+		
+		MagmaWorm = 10,
+		
+		FiendWorm = 11,
 
 		BruteLeech = 12,
 
 		CraneFly = 13,
+		
+		KukuruPowder = 30,
 
-		KukuruPowder = 22,
+		BouillonCube = 31,
 
-		BouillonCube = 23,
+		BeanSauce = 32, 
 
-		BeanSauce = 24,
-
-		BeanPaste = 25
+		BeanPaste = 33,
+		
+		GoldenApple = 34,
+		
+		SolsticeGarlic = 35,
+		
+		MatureOliveOil = 36,
+		
+		LoaghtanFilet = 37,
+		
+		PowderedMermanHorn = 38,
 	}
 }


### PR DESCRIPTION
- Fixed Idyllshire NPC's location for turn-in/scrip shop (scrip shop npc was too far sometimes)
- Fixed and added relevant pre-3.2 blue scrip crafter items
- Added relevant 3.2 blue scrip crafter items
- Separated data between RB_CN client and the others (RB_CN not fixed, still old datas)
