### PR TITLE
New Rotations

### DIFF
--- a/ExBuddy/OrderBotTags/Gather/Rotations/Collect321GatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/Collect321GatheringRotation.cs
@@ -1,0 +1,47 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+	using System.Threading.Tasks;
+	using Attributes;
+	using Interfaces;
+	using ff14bot;
+
+	[GatheringRotation("Collect321", 30, 600)]
+	public sealed class Collect321GatheringRotation : CollectableGatheringRotation, IGetOverridePriority
+	{
+		#region IGetOverridePriority Members
+		int IGetOverridePriority.GetOverridePriority(ExGatherTag tag)
+		{
+			// if we have a collectable && the collectable value is greater than or equal to 321: Priority 321
+			if (tag.CollectableItem != null && tag.CollectableItem.Value >= 321)
+			{
+				return 321;
+			}
+			return -1;
+		}
+		#endregion
+		public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+		{
+			if (tag.IsUnspoiled())
+			{
+				await SingleMindImpulsive(tag);
+				await SingleMindImpulsive(tag);
+				await SingleMindMethodical(tag);
+			}
+			else
+			{
+				if (Core.Player.CurrentGP >= 600)
+				{
+					await SingleMindImpulsive(tag);
+					await SingleMindImpulsive(tag);
+					await SingleMindMethodical(tag);
+					return true;
+				}
+				
+				await Impulsive(tag);
+				await Impulsive(tag);
+				await Methodical(tag);
+			}
+			return true;
+		}
+	}
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/Collect346GatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/Collect346GatheringRotation.cs
@@ -1,0 +1,47 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+	using System.Threading.Tasks;
+	using Attributes;
+	using Interfaces;
+	using ff14bot;
+
+	[GatheringRotation("Collect346", 30, 600)]
+	public sealed class Collect346GatheringRotation : CollectableGatheringRotation, IGetOverridePriority
+	{
+		#region IGetOverridePriority Members
+		int IGetOverridePriority.GetOverridePriority(ExGatherTag tag)
+		{
+			// if we have a collectable && the collectable value is greater than or equal to 346: Priority 346
+			if (tag.CollectableItem != null && tag.CollectableItem.Value >= 346)
+			{
+				return 346;
+			}
+			return -1;
+		}
+		#endregion
+		public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+		{
+			if (tag.IsUnspoiled())
+			{
+				await SingleMindMethodical(tag);
+				await SingleMindMethodical(tag);
+				await SingleMindMethodical(tag);
+			}
+			else
+			{
+				if (Core.Player.CurrentGP >= 600)
+				{
+					await SingleMindMethodical(tag);
+					await SingleMindMethodical(tag);
+					await SingleMindMethodical(tag);
+					return true;
+				}
+				
+				await Methodical(tag);
+				await Methodical(tag);
+				await Methodical(tag);
+			}
+			return true;
+		}
+	}
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/Collect402GatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/Collect402GatheringRotation.cs
@@ -1,0 +1,47 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+	using System.Threading.Tasks;
+	using Attributes;
+	using Interfaces;
+	using ff14bot;
+
+	[GatheringRotation("Collect402", 30, 600)]
+	public sealed class Collect402GatheringRotation : CollectableGatheringRotation, IGetOverridePriority
+	{
+		#region IGetOverridePriority Members
+		int IGetOverridePriority.GetOverridePriority(ExGatherTag tag)
+		{
+			// if we have a collectable && the collectable value is greater than or equal to 402: Priority 402
+			if (tag.CollectableItem != null && tag.CollectableItem.Value >= 402)
+			{
+				return 402;
+			}
+			return -1;
+		}
+		#endregion
+		public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+		{
+			if (tag.IsUnspoiled())
+			{
+				await SingleMindMethodical(tag);
+				await SingleMindMethodical(tag);
+				await DiscerningMethodical(tag);
+			}
+			else
+			{
+				if (Core.Player.CurrentGP >= 600)
+				{
+					await SingleMindMethodical(tag);
+					await SingleMindMethodical(tag);
+					await DiscerningMethodical(tag);
+					return true;
+				}
+				
+				await Impulsive(tag);
+				await Impulsive(tag);
+				await Methodical(tag);
+			}
+			return true;
+		}
+	}
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/Collect410GatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/Collect410GatheringRotation.cs
@@ -1,0 +1,47 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+	using System.Threading.Tasks;
+	using Attributes;
+	using Interfaces;
+	using ff14bot;
+
+	[GatheringRotation("Collect410", 30, 600)]
+	public sealed class Collect410GatheringRotation : CollectableGatheringRotation, IGetOverridePriority
+	{
+		#region IGetOverridePriority Members
+		int IGetOverridePriority.GetOverridePriority(ExGatherTag tag)
+		{
+			// if we have a collectable && the collectable value is greater than or equal to 410: Priority 410
+			if (tag.CollectableItem != null && tag.CollectableItem.Value >= 410)
+			{
+				return 410;
+			}
+			return -1;
+		}
+		#endregion
+		public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+		{
+			if (tag.IsUnspoiled())
+			{
+				await AppraiseAndRebuff(tag);
+				await AppraiseAndRebuff(tag);
+				await Methodical(tag);
+			}
+			else
+			{
+				if (Core.Player.CurrentGP >= 600)
+				{
+					await AppraiseAndRebuff(tag);
+					await AppraiseAndRebuff(tag);
+					await Methodical(tag);
+					return true;
+				}
+
+				await Impulsive(tag);
+				await Impulsive(tag);
+				await Methodical(tag);
+			}
+			return true;
+		}
+	}
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/Collect459GatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/Collect459GatheringRotation.cs
@@ -1,0 +1,47 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+	using System.Threading.Tasks;
+	using Attributes;
+	using Interfaces;
+	using ff14bot;
+
+	[GatheringRotation("Collect459", 30, 600)]
+	public sealed class Collect459GatheringRotation : CollectableGatheringRotation, IGetOverridePriority
+	{
+		#region IGetOverridePriority Members
+		int IGetOverridePriority.GetOverridePriority(ExGatherTag tag)
+		{
+			// if we have a collectable && the collectable value is greater than or equal to 459: Priority 459
+			if (tag.CollectableItem != null && tag.CollectableItem.Value >= 459)
+			{
+				return 459;
+			}
+			return -1;
+		}
+		#endregion
+		public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+		{
+			if (tag.IsUnspoiled())
+			{
+				await SingleMindMethodical(tag);
+				await DiscerningMethodical(tag);
+				await DiscerningMethodical(tag);
+			}
+			else
+			{
+				if (Core.Player.CurrentGP >= 600)
+				{
+					await SingleMindMethodical(tag);
+					await DiscerningMethodical(tag);
+					await DiscerningMethodical(tag);
+					return true;
+				}
+
+				await Impulsive(tag);
+				await Impulsive(tag);
+				await Methodical(tag);
+			}
+			return true;
+		}
+	}
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/Collect460GatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/Collect460GatheringRotation.cs
@@ -1,0 +1,53 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+	using System.Threading.Tasks;
+	using Attributes;
+	using Interfaces;
+	using ff14bot;
+
+	[GatheringRotation("Collect460", 33, 600)]
+	public sealed class Collect460GatheringRotation : CollectableGatheringRotation, IGetOverridePriority
+	{
+		#region IGetOverridePriority Members
+		int IGetOverridePriority.GetOverridePriority(ExGatherTag tag)
+		{
+			// if we have a collectable && the collectable value is greater than or equal to 460: Priority 460
+			if (tag.CollectableItem != null && tag.CollectableItem.Value >= 460)
+			{
+				return 460;
+			}
+			return -1;
+		}
+		#endregion
+		public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+		{
+			if (tag.IsUnspoiled())
+			{
+				await SingleMindMethodical(tag);
+				await SingleMindMethodical(tag);
+				await UtmostCaution(tag);
+				await Methodical(tag);
+				await UtmostCaution(tag);
+				await Methodical(tag);
+			}
+			else
+			{
+				if (Core.Player.CurrentGP >= 600)
+				{
+					await SingleMindMethodical(tag);
+					await SingleMindMethodical(tag);
+					await UtmostCaution(tag);
+					await Methodical(tag);
+					await UtmostCaution(tag);
+					await Methodical(tag);
+					return true;
+				}
+				
+				await Impulsive(tag);
+				await Impulsive(tag);
+				await Methodical(tag);
+			}
+			return true;
+		}
+	}
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/Collect515GatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/Collect515GatheringRotation.cs
@@ -1,0 +1,47 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+	using System.Threading.Tasks;
+	using Attributes;
+	using Interfaces;
+	using ff14bot;
+
+	[GatheringRotation("Collect515", 30, 600)]
+	public sealed class Collect515GatheringRotation : CollectableGatheringRotation, IGetOverridePriority
+	{
+		#region IGetOverridePriority Members
+		int IGetOverridePriority.GetOverridePriority(ExGatherTag tag)
+		{
+			// if we have a collectable && the collectable value is greater than or equal to 515: Priority 515
+			if (tag.CollectableItem != null && tag.CollectableItem.Value >= 515)
+			{
+				return 515;
+			}
+			return -1;
+		}
+		#endregion
+		public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+		{
+			if (tag.IsUnspoiled())
+			{
+				await DiscerningMethodical(tag);
+				await DiscerningMethodical(tag);
+				await DiscerningMethodical(tag);
+			}
+			else
+			{
+				if (Core.Player.CurrentGP >= 600)
+				{
+					await DiscerningMethodical(tag);
+					await DiscerningMethodical(tag);
+					await DiscerningMethodical(tag);
+					return true;
+				}
+
+				await Impulsive(tag);
+				await Impulsive(tag);
+				await Methodical(tag);
+			}
+			return true;
+		}
+	}
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/EarthElementGatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/EarthElementGatheringRotation.cs
@@ -1,0 +1,22 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+    using System.Threading.Tasks;
+    using Attributes;
+    using ff14bot;
+    using ff14bot.Managers;
+
+    [GatheringRotation("EarthElement", 30, 400)]
+    public sealed class EarthElementGatheringRotation : SmartGatheringRotation
+    {
+        public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+        {
+            if (Core.Player.CurrentGP > 399)
+            {
+                await Wait();
+                Actionmanager.DoAction(217U, Core.Player);
+            }
+
+            return await base.ExecuteRotation(tag);
+        }
+    }
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/FireElementGatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/FireElementGatheringRotation.cs
@@ -1,0 +1,22 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+    using System.Threading.Tasks;
+    using Attributes;
+    using ff14bot;
+    using ff14bot.Managers;
+
+    [GatheringRotation("FireElement", 30, 400)]
+    public sealed class FireElementGatheringRotation : SmartGatheringRotation
+    {
+        public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+        {
+            if (Core.Player.CurrentGP > 399)
+            {
+                await Wait();
+                Actionmanager.DoAction(234U, Core.Player);
+            }
+
+            return await base.ExecuteRotation(tag);
+        }
+    }
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/IceElementGatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/IceElementGatheringRotation.cs
@@ -1,0 +1,22 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+    using System.Threading.Tasks;
+    using Attributes;
+    using ff14bot;
+    using ff14bot.Managers;
+
+    [GatheringRotation("IceElement", 30, 400)]
+    public sealed class IceElementGatheringRotation : SmartGatheringRotation
+    {
+        public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+        {
+            if (Core.Player.CurrentGP > 399)
+            {
+                await Wait();
+                Actionmanager.DoAction(236U, Core.Player);
+            }
+
+            return await base.ExecuteRotation(tag);
+        }
+    }
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/LightningElementGatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/LightningElementGatheringRotation.cs
@@ -1,0 +1,22 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+    using System.Threading.Tasks;
+    using Attributes;
+    using ff14bot;
+    using ff14bot.Managers;
+
+    [GatheringRotation("LightningElement", 30, 400)]
+    public sealed class LightningElementGatheringRotation : SmartGatheringRotation
+    {
+        public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+        {
+            if (Core.Player.CurrentGP > 399)
+            {
+                await Wait();
+                Actionmanager.DoAction(219U, Core.Player);
+            }
+
+            return await base.ExecuteRotation(tag);
+        }
+    }
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/WaterElementGatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/WaterElementGatheringRotation.cs
@@ -1,0 +1,22 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+    using System.Threading.Tasks;
+    using Attributes;
+    using ff14bot;
+    using ff14bot.Managers;
+
+    [GatheringRotation("WaterElement", 30, 400)]
+    public sealed class WaterElementGatheringRotation : SmartGatheringRotation
+    {
+        public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+        {
+            if (Core.Player.CurrentGP > 399)
+            {
+                await Wait();
+                Actionmanager.DoAction(293U, Core.Player);
+            }
+            
+            return await base.ExecuteRotation(tag);
+        }
+    }
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/WindElementGatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/WindElementGatheringRotation.cs
@@ -1,0 +1,22 @@
+﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
+{
+    using System.Threading.Tasks;
+    using Attributes;
+    using ff14bot;
+    using ff14bot.Managers;
+
+    [GatheringRotation("WindElement", 30, 400)]
+    public sealed class WindElementGatheringRotation : SmartGatheringRotation
+    {
+        public override async Task<bool> ExecuteRotation(ExGatherTag tag)
+        {
+            if (Core.Player.CurrentGP > 399)
+            {
+                await Wait();
+                Actionmanager.DoAction(292U, Core.Player);
+            }
+
+            return await base.ExecuteRotation(tag);
+        }
+    }
+}

--- a/ExBuddy/OrderBotTags/Gather/Rotations/YieldAndQualityGatheringRotation.cs
+++ b/ExBuddy/OrderBotTags/Gather/Rotations/YieldAndQualityGatheringRotation.cs
@@ -1,15 +1,15 @@
 ﻿namespace ExBuddy.OrderBotTags.Gather.Rotations
 {
 	using System.Threading.Tasks;
-	using ExBuddy.Attributes;
-	using ExBuddy.Enumerations;
-	using ExBuddy.Helpers;
-	using ExBuddy.Interfaces;
+	using Attributes;
+	using Enumerations;
+	using Helpers;
+	using Interfaces;
 	using ff14bot;
 	using ff14bot.Managers;
-
+    	
 	//Name, RequiredTime, RequiredGpBreakpoints
-	[GatheringRotation("YieldAndQuality", 22, 600, 500, 0)]
+	[GatheringRotation("YieldAndQuality", 25, 700, 650, 600, 500, 0)]
 	public class YieldAndQualityGatheringRotation : SmartGatheringRotation, IGetOverridePriority
 	{
 		#region IGetOverridePriority Members
@@ -50,9 +50,21 @@
 					if (Core.Player.CurrentGP >= 100)
 					{
 						await tag.Cast(Ability.IncreaseGatherQuality10);
-					}
 
-					return await base.ExecuteRotation(tag);
+                        if (Core.Player.CurrentGP >= 100 && tag.GatherItem.Chance < 95)
+                        {
+                            await tag.Cast(Ability.IncreaseGatherChance15);
+                        }
+                        else
+                        {
+                            if (Core.Player.CurrentGP >= 50 && tag.GatherItem.Chance < 100)
+                            {
+                                await tag.Cast(Ability.IncreaseGatherChance5);
+                            }
+                        }
+
+                        return await base.ExecuteRotation(tag);
+					}
 				}
 			}
 


### PR DESCRIPTION
- All rotation used for Ephemeral and Collectable items that are always
available (Tektite, Cloud Mushroom..)

- Specific element rotation for Revenant's toll Unspoiled

- Yield and Quality rotation updated to be used with 600, 650 or 700 GP.